### PR TITLE
Fix: cleaning up usersessions could modify the list while iterating

### DIFF
--- a/bananas_api/helpers/user_session.py
+++ b/bananas_api/helpers/user_session.py
@@ -53,7 +53,10 @@ async def check_expire():
     while True:
         await asyncio.sleep(TIME_BETWEEN_CHECKS)
 
-        for user in _sessions.values():
+        # Cast it into a list, as on expire we are going to modify _session.
+        # This would cause "dictionary changed size during iteration"
+        # otherwise.
+        for user in list(_sessions.values()):
             user.check_expire()
 
 


### PR DESCRIPTION
This causes the Python exception "dictionary changed size during
iteration".

Solve this by first making a new list out of it, before iterating.