### PR TITLE
Add: allow setting Authorization / Upload-Token in Metadata for tus-clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![GitHub deployments (Staging)](https://img.shields.io/github/deployments/OpenTTD/bananas-api/staging?label=staging)](https://github.com/OpenTTD/bananas-api/deployments)
 [![GitHub deployments (Production)](https://img.shields.io/github/deployments/OpenTTD/bananas-api/production?label=production)](https://github.com/OpenTTD/bananas-api/deployments)
 
-
 This is the HTTP API for OpenTTD's content service, called BaNaNaS.
 It works together with [bananas-server](https://github.com/OpenTTD/bananas-server), which serves the in-game client.
 


### PR DESCRIPTION
When you upload via a webinterface in the development setup, tusd
is running on a different port than the API server. This means CORS
is in control if you are allowed to call tusd. In the current
implementation of tusd, it is not possible to modify the CORS headers,
and the author has been very strict that this is not going to change.
The CORS headers tusd does send are, rightfully, very strict, and
do not allow these two new headers to be send. In result, uploading
to tusd over via a website is not working for a development setup.

In production this is not a problem, because there everything is on
the same URL.

To still allow development setups to work, it is now okay to send
these two headers via the Metadata. This has some downsides, for
example a WAF can no longer validate these requests. Or for example
caching doesn't spot the Authorization header, not knowing how to
cache correctly. For now, this is not an issue, as we don't use a
WAF (and are unlikely to ever use one), and we can put the whole
tus path on "do-not-cache".

Nevertheless, this is a hack.