### PR TITLE
Add: tus-endpoint now only needs upload-token and moved to Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![GitHub deployments (Staging)](https://img.shields.io/github/deployments/OpenTTD/bananas-api/staging?label=staging)](https://github.com/OpenTTD/bananas-api/deployments)
 [![GitHub deployments (Production)](https://img.shields.io/github/deployments/OpenTTD/bananas-api/production?label=production)](https://github.com/OpenTTD/bananas-api/deployments)
 
-
 This is the HTTP API for OpenTTD's content service, called BaNaNaS.
 It works together with [bananas-server](https://github.com/OpenTTD/bananas-server), which serves the in-game client.
 

--- a/bananas_api/web_routes/new.py
+++ b/bananas_api/web_routes/new.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import os
 
@@ -15,12 +16,14 @@ from ..helpers.web_routes import (
     in_header_authorization,
     in_path_file_uuid,
     in_path_upload_token,
+    JSONException,
 )
 from ..new_upload.exceptions import ValidationException
 from ..new_upload.session import (
     add_file,
     create_token,
     get_session,
+    get_session_by_token,
     publish_session,
     update_session,
     validate_session,
@@ -42,13 +45,6 @@ async def tusd_handler(request):
     # Example: { "Upload-Length": [ 12 ] } becomes { "Upload-Length": 12 }.
     headers = {k: v[-1] for k, v in headers.items()}
 
-    user = in_header_authorization(headers)
-    upload_token = in_path_upload_token(headers.get("Upload-Token"))
-
-    session = get_session(user, upload_token)
-    if session is None:
-        return web.HTTPNotFound()
-
     hook_name = request.headers.get("Hook-Name")
     if hook_name == "pre-create":
         if "Upload-Metadata" not in headers:
@@ -58,13 +54,40 @@ async def tusd_handler(request):
         # separated per key-value pair, which is stored space separated. On
         # top of that, the value is base64 encoded. In other words:
         # "key base64-value,key base64-value,.."
-        metadata = dict([e.split(" ") for e in headers.get("Upload-Metadata").split(",")])
+        try:
+            metadata = dict([e.split(" ") for e in headers.get("Upload-Metadata", "").split(",")])
+            for key, value in metadata.items():
+                metadata[key] = base64.b64decode(value).decode()
+        except Exception:
+            raise JSONException({"message": "Upload-Metadata header is invalid"})
+
         if not metadata.get("filename"):
             return web.json_response({"message": "no filename given in metadata"}, status=400)
 
+        if not metadata.get("upload-token"):
+            return web.json_response({"message": "no upload-token given in metadata"}, status=400)
+
+        upload_token = in_path_upload_token(metadata.get("upload-token"))
+
+        session = get_session_by_token(upload_token)
+        if session is None:
+            return web.HTTPNotFound()
+
         return web.HTTPOk()
-    elif hook_name == "post-create":
+
+    if hook_name in ("post-create", "post-finish"):
         payload = await request.json()
+
+        upload_token = in_path_upload_token(payload["Upload"]["MetaData"]["upload-token"])
+
+        session = get_session_by_token(upload_token)
+        if session is None:
+            return web.HTTPNotFound()
+
+        if hook_name == "post-create":
+            announcing = True
+        else:
+            announcing = False
 
         add_file(
             session,
@@ -72,20 +95,9 @@ async def tusd_handler(request):
             payload["Upload"]["MetaData"]["filename"],
             payload["Upload"]["Size"],
             payload["Upload"]["Storage"]["Path"],
-            announcing=True,
+            announcing=announcing,
         )
 
-        return web.HTTPOk()
-    elif hook_name == "post-finish":
-        payload = await request.json()
-
-        add_file(
-            session,
-            payload["Upload"]["ID"],
-            payload["Upload"]["MetaData"]["filename"],
-            payload["Upload"]["Size"],
-            payload["Upload"]["Storage"]["Path"],
-        )
         return web.HTTPOk()
 
     log.warning("Unexpected hook-name: %s", hook_name)

--- a/regression_runner/__main__.py
+++ b/regression_runner/__main__.py
@@ -356,10 +356,10 @@ async def handle_file_upload(step):
         filename = step["name"]
 
     tus = TusClient("http://127.0.0.1:1080/new-package/tus/")
-    tus.set_headers({"Upload-Token": token})
-    tus.set_headers({"Authorization": auth_headers["Authorization"]})
     try:
-        uploader = tus.uploader(fullpath, chunk_size=5 * 1024 * 1024, metadata={"filename": filename})
+        uploader = tus.uploader(
+            fullpath, chunk_size=5 * 1024 * 1024, metadata={"filename": filename, "upload-token": token}
+        )
     except Exception:
         raise RegressionFailure(f"Couldn't upload file '{filename}'")
     uploader.upload()


### PR DESCRIPTION
When using web-frontends around this API, two problems had to be
solved when uploading to tus:

1) tus needed the api-token, but the web-frontend normally doesn't
show this (as it is between the web-frontend server and the API;
the client has nothing to do with this). So switching to upload-token
only solves this problem. This is also security-wise safe, as the
upload-token is a secret generated on-demand. And it only lives for
roughly 15 minutes.

2) CORS is implemented, correctly, rather strict in tusd. This means
that we cannot use additional headers outside the ones in the CORS
header. This means that the upload-token has to move from headers
to Metadata. This also means that we have to trust the information
on disk about the upload. This too is security-wise safe, as this
file-uuid is a secret generated on-demand.

This commit combines these two findings and solves them both.