### PR TITLE
Fix: there is no .info file for extracted files

### DIFF
--- a/bananas_api/web_routes/new.py
+++ b/bananas_api/web_routes/new.py
@@ -163,12 +163,15 @@ async def new_delete_file(request):
     if session is None:
         return web.HTTPNotFound()
 
-    for file_info in session["files"]:
+    for file_info in list(session["files"]):
         if file_info["uuid"] == file_uuid:
+            session["files"].remove(file_info)
+
             internal_filename = file_info["internal_filename"]
             os.remove(internal_filename)
-            os.remove(f"{internal_filename}.info")
-            session["files"].remove(file_info)
+            if not internal_filename.startswith("data/tar/"):
+                os.remove(f"{internal_filename}.info")
+
             break
     else:
         return web.HTTPNotFound()


### PR DESCRIPTION
Also, while at it, make sure we forget the reference before we
remove the file. In case this happens again, the impact would be
a lot smaller.