### PR TITLE
Fix #65: ignore errors in tarballs/zipfiles

### DIFF
--- a/bananas_api/new_upload/exceptions.py
+++ b/bananas_api/new_upload/exceptions.py
@@ -1,3 +1,7 @@
+class ArchiveError(Exception):
+    """Failed to read an uploaded archive"""
+
+
 class ValidationException(Exception):
     pass
 

--- a/bananas_api/new_upload/validate.py
+++ b/bananas_api/new_upload/validate.py
@@ -34,6 +34,9 @@ from .readers.script import (
     Script,
 )
 
+TARBALL_EXTENSIONS = (".tar", ".tar.gz", ".tgz")
+ZIPFILE_EXTENSIONS = (".zip",)
+
 log = logging.getLogger(__name__)
 
 READERS = {
@@ -192,6 +195,12 @@ def validate_files(files):
     errors = False
     objects = []
     for file_info in files:
+        # Archives that still exist already have an error attached to them, so
+        # ignore further validation on them.
+        if file_info["filename"].endswith(TARBALL_EXTENSIONS + ZIPFILE_EXTENSIONS):
+            assert len(file_info["errors"]) == 1
+            continue
+
         file_info["errors"] = []
 
         with open(file_info["internal_filename"], "rb") as fp:

--- a/regression/901_empty_tarball.yaml
+++ b/regression/901_empty_tarball.yaml
@@ -1,0 +1,15 @@
+steps:
+- api: user/login
+- api: new-package/start
+- file-upload: empty
+  name: empty.tar
+- file-upload: empty
+  name: empty.tar.gz
+- file-upload: empty
+  name: empty.tgz
+- api: new-package/publish
+  error: "empty.tar: couldn't extract archive file; is it a valid tarball?"
+- api: new-package/publish
+  error: "empty.tar.gz: couldn't extract archive file; is it a valid tarball?"
+- api: new-package/publish
+  error: "empty.tgz: couldn't extract archive file; is it a valid tarball?"

--- a/regression/902_empty_zipfile.yaml
+++ b/regression/902_empty_zipfile.yaml
@@ -1,0 +1,7 @@
+steps:
+- api: user/login
+- api: new-package/start
+- file-upload: empty
+  name: empty.zip
+- api: new-package/publish
+  error: "empty.zip: couldn't extract archive file; is it a valid zipfile?"


### PR DESCRIPTION
There currently isn't really a way to talk back to the client that
they uploaded an invalid tarball/zipfile. So far this only happened
when someone uploaded a zero-byte tarball, which is pretty obvious.
Hopefully that remains this way.

The behaviour is now: if you upload an invalid tarball/zipfile,
after pressing validate, the file is no longer in the filelist.
Hopefully that gives enough clues to the user what is going on.