### PR TITLE
Change: More descriptive exceptions on /user/token endpoint

### DIFF
--- a/bananas_api/web_routes/user.py
+++ b/bananas_api/web_routes/user.py
@@ -82,10 +82,10 @@ async def oauth_token(request):
         return web.HTTPNotFound()
 
     if not user.validate(code_verifier):
-        return web.HTTPNotFound()
+        raise JSONException({"message": "Could not verify using the code verifier"})
 
     if user.redirect_uri != redirect_uri:
-        return web.HTTPNotFound()
+        raise JSONException({"message": "Invalid redirect_uri"})
 
     user_login = UserToken().dump({"access_token": user.bearer_token, "token_type": "Bearer"})
     return web.json_response(user_login)


### PR DESCRIPTION
I'm developing a CLI and have been quite overwhelmed with the 404s and 500 exceptions. With this, I think the errors should be easier to handle for any developer trying to authenticate. If the user cannot be found by code, it still throws a 404 exception.

One could technically just put a 403 for the code_verifier exception, as that would fit more than a 404.