### PR TITLE
Fix: [Actions] queue publish / deployments jobs so they are executed in order

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,6 +3,8 @@ name: Deployment
 on:
   deployment:
 
+concurrency: ${{ github.event.deployment.environment }}
+
 jobs:
   deploy_to_aws:
     name: Deploy to AWS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ on:
     - publish_latest_tag
     - publish_master
 
+concurrency: publish
+
 jobs:
   publish_image:
     name: Publish image


### PR DESCRIPTION
This ensures that if we push twice in quick succession, nothing breaks, and the latest version is pushed correctly to staging.