### PR TITLE
Change: rename "master" to "official", as it is not referencing a branch

### DIFF
--- a/bananas_api/helpers/enums.py
+++ b/bananas_api/helpers/enums.py
@@ -47,7 +47,8 @@ class License(Enum):
 
 
 class Branch(Enum):
-    OFFICIAL_OPENTTD = "master"
+    OFFICIAL_OPENTTD = "official"
+    OLD_OFFICIAL_OPENTTD = "master"
 
 
 class Availability(Enum):

--- a/bananas_api/web_routes/config.py
+++ b/bananas_api/web_routes/config.py
@@ -18,6 +18,7 @@ routes = web.RouteTableDef()
 
 BRANCHES = {
     Branch.OFFICIAL_OPENTTD: "Official OpenTTD",
+    Branch.OLD_OFFICIAL_OPENTTD: "Official OpenTTD",
 }
 # Make sure all entries of Branch are in the dict above
 assert all(branch in BRANCHES for branch in Branch)

--- a/regression/000_success_newgrf.yaml
+++ b/regression/000_success_newgrf.yaml
@@ -14,7 +14,7 @@ steps:
   - "tag1"
   - "tag2"
   compatibility:
-  - name: master
+  - name: official
     conditions:
     - ">= 1.0.0"
     - "< 1.10.0"
@@ -28,7 +28,7 @@ steps:
   - "tag1"
   - "tag2"
   compatibility:
-  - name: master
+  - name: official
     conditions:
     - ">= 1.0.0"
     - "< 1.10.0"

--- a/regression/950_condition_invalid.yaml
+++ b/regression/950_condition_invalid.yaml
@@ -4,7 +4,7 @@ steps:
 - file-upload: valid.grf
 - api: new-package/update
   compatibility:
-  - name: master
+  - name: official
     conditions:
     - "! 1.9.0"
   error:

--- a/regression/951_condition_wrong_order.yaml
+++ b/regression/951_condition_wrong_order.yaml
@@ -4,7 +4,7 @@ steps:
 - file-upload: valid.grf
 - api: new-package/update
   compatibility:
-  - name: master
+  - name: official
     conditions:
     - "< 1.9.0"
     - ">= 1.8.0"

--- a/regression/952_condition_twice.yaml
+++ b/regression/952_condition_twice.yaml
@@ -4,7 +4,7 @@ steps:
 - file-upload: valid.grf
 - api: new-package/update
   compatibility:
-  - name: master
+  - name: official
     conditions:
     - ">= 1.9.0"
     - ">= 1.8.0"


### PR DESCRIPTION
```
It points to for example official vs patch-packs, to allow
future-extensions have uploads that are restricted to patch-packs.
```

This commit allows us to deploy this, and rename the entries in the storage. After that is done, we can remove the old entry.

While we are doing this, temporary the frontend will show two compatibility lines. This might seem a bit off, but the window this is happening in should be rather short.