### PR TITLE
Fix: rename NewGRF classifier "resolution" to "has-high-res"

### DIFF
--- a/bananas_api/helpers/api_schema.py
+++ b/bananas_api/helpers/api_schema.py
@@ -17,7 +17,6 @@ from .enums import (
     License,
     NewGRFSet,
     Palette,
-    Resolution,
     Status,
 )
 
@@ -195,7 +194,7 @@ class Compatability(OrderedSchema):
 class Classification(OrderedSchema):
     set = EnumField(NewGRFSet, by_value=True)
     palette = EnumField(Palette, by_value=True)
-    resolution = EnumField(Resolution, by_value=True)
+    has_high_res = fields.Boolean(data_key="has-high-res")
     has_sound_effects = fields.Boolean(data_key="has-sound-effects")
 
 

--- a/bananas_api/helpers/enums.py
+++ b/bananas_api/helpers/enums.py
@@ -89,8 +89,3 @@ class NewGRFSet(Enum):
 class Palette(Enum):
     BPP_32 = "32bpp"
     BPP_8 = "8bpp"
-
-
-class Resolution(Enum):
-    HIGH = "high"
-    STANDARD = "standard"

--- a/bananas_api/new_upload/classifiers/newgrf.py
+++ b/bananas_api/new_upload/classifiers/newgrf.py
@@ -2,7 +2,6 @@ from ...helpers.api_schema import Classification
 from ...helpers.enums import (
     NewGRFSet,
     Palette,
-    Resolution,
 )
 from ..readers.newgrf import (
     Feature,
@@ -179,9 +178,9 @@ def classify_newgrf(newgrf: NewGRF) -> Classification:
 
     # If over 50% of the sprites are zoomed in, classify as high resolution.
     if len(features.get(Feature.SPRITES_ZOOMIN, [])) > len(features.get(Feature.SPRITES, [])) / 2:
-        classification["resolution"] = Resolution.HIGH
+        classification["has-high-res"] = True
     else:
-        classification["resolution"] = Resolution.STANDARD
+        classification["has-high-res"] = False
 
     # Features not used for further classification.
     for feature in (Feature.SOUND_EFFECTS, Feature.SPRITES, Feature.SPRITES_32BPP, Feature.SPRITES_ZOOMIN):


### PR DESCRIPTION
It makes more sense, to have it as a toggle. High/standard doesn't sound good.