### PR TITLE
Add: classify heightmaps with the information we can extract from it

### DIFF
--- a/bananas_api/helpers/api_schema.py
+++ b/bananas_api/helpers/api_schema.py
@@ -17,7 +17,10 @@ from .enums import (
     License,
     NewGRFSet,
     Palette,
+    Resolution,
+    Shape,
     Status,
+    TerrainType,
 )
 
 DEPENDENCY_CHECK = True
@@ -196,6 +199,9 @@ class Classification(OrderedSchema):
     palette = EnumField(Palette, by_value=True)
     has_high_res = fields.Boolean(data_key="has-high-res")
     has_sound_effects = fields.Boolean(data_key="has-sound-effects")
+    shape = EnumField(Shape, by_value=True)
+    resolution = EnumField(Resolution, by_value=True)
+    terrain_type = EnumField(TerrainType, by_value=True, data_key="terrain-type")
 
 
 class VersionMinimized(Global):

--- a/bananas_api/helpers/enums.py
+++ b/bananas_api/helpers/enums.py
@@ -89,3 +89,22 @@ class NewGRFSet(Enum):
 class Palette(Enum):
     BPP_32 = "32bpp"
     BPP_8 = "8bpp"
+
+
+class Resolution(Enum):
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+
+
+class Shape(Enum):
+    SQUARE = "square"
+    RECTANGLE = "rectangle"
+    NARROW = "narrow"
+
+
+class TerrainType(Enum):
+    VERY_FLAT = "very-flat"
+    FLAT = "flat"
+    HILLY = "hilly"
+    MOUNTAINOUS = "mountainous"

--- a/bananas_api/new_upload/classifiers/heightmap.py
+++ b/bananas_api/new_upload/classifiers/heightmap.py
@@ -1,0 +1,56 @@
+from ...helpers.api_schema import Classification
+from ...helpers.enums import (
+    Resolution,
+    Shape,
+    TerrainType,
+)
+from ..readers.heightmap import Heightmap
+
+
+def classify_heightmap(heightmap: Heightmap) -> Classification:
+    classification = {}
+
+    surface = heightmap.size[0] * heightmap.size[1]
+    if surface < 256 * 256:
+        classification["resolution"] = Resolution.LOW
+    elif surface < 1024 * 1024:
+        classification["resolution"] = Resolution.NORMAL
+    else:
+        classification["resolution"] = Resolution.HIGH
+
+    aspect_ratio = heightmap.size[0] / heightmap.size[1]
+    if aspect_ratio < 1:
+        aspect_ratio = 1 / aspect_ratio
+
+    if aspect_ratio < 1.2:
+        classification["shape"] = Shape.SQUARE
+    elif aspect_ratio < 2.5:
+        classification["shape"] = Shape.RECTANGLE
+    else:
+        classification["shape"] = Shape.NARROW
+
+    # Change the histogram in small bins, skipping sea-level.
+    small_histogram = [0] * 16
+    for i, value in enumerate(heightmap.histogram):
+        if i == 0:
+            continue
+        small_histogram[i // 16] += value
+    # Normalize the histogram.
+    small_histogram = [value * 100 / (surface - heightmap.histogram[0]) for value in small_histogram]
+
+    # Find all elevations with a certain surface amount. One hill doesn't
+    # make a mountain (yes, this is meant ironically).
+    common_elevations = [i for i, v in enumerate(small_histogram) if v >= 1]
+    # And check the difference between the highest and lowest elevation.
+    height_difference = max(common_elevations) - min(common_elevations)
+
+    if height_difference > 9:
+        classification["terrain-type"] = TerrainType.MOUNTAINOUS
+    elif height_difference > 4:
+        classification["terrain-type"] = TerrainType.HILLY
+    elif height_difference > 1:
+        classification["terrain-type"] = TerrainType.FLAT
+    else:
+        classification["terrain-type"] = TerrainType.VERY_FLAT
+
+    return Classification().load(classification)

--- a/bananas_api/new_upload/readers/heightmap.py
+++ b/bananas_api/new_upload/readers/heightmap.py
@@ -6,6 +6,10 @@ from ..exceptions import ValidationException
 from ...helpers.enums import PackageType
 
 
+def rgb_to_gray(color):
+    return ((color[0] * 19595) + (color[1] * 38470) + (color[2] * 7471)) // 65536
+
+
 class Heightmap:
     """
     Heightmap meta data.
@@ -15,6 +19,9 @@ class Heightmap:
 
     @ivar size: Image size
     @type size: (C{int}, C{int})
+
+    @ivar histogram: List of 256 entries indicating how often that height level occurs
+    @type histogram: C{list} of C{int}
     """
 
     package_type = PackageType.HEIGHTMAP
@@ -22,6 +29,7 @@ class Heightmap:
     def __init__(self):
         self.md5sum = None
         self.size = (None, None)
+        self.histogram = None
 
     def read(self, fp):
         """
@@ -39,6 +47,49 @@ class Heightmap:
 
         try:
             im = Image.open(fp)
-            self.size = im.size
         except Exception:
             raise ValidationException("File is not a valid image.")
+
+        # Limit the size of heightmaps, as otherwise it could allocate a lot of
+        # memory for clients loading the map.
+        if im.width * im.height > 16384 * 16384:
+            raise ValidationException("Image is too large.")
+
+        self.size = im.size
+
+        # The following code is based on https://github.com/OpenTTD/OpenTTD/blob/master/src/heightmap.cpp
+        # to mimic the heightmap loading in OpenTTD as much as possible.
+
+        if im.palette:
+            palette = im.palette.palette
+            mode_len = len(im.palette.mode)
+
+            gray_palette = []
+            all_gray = True
+            for i in range(0, len(palette), mode_len):
+                color = palette[i : i + mode_len]
+                all_gray = all_gray and (color[0] == color[1] and color[1] == color[2])
+                gray_palette.append(rgb_to_gray(color))
+
+            palette_size = len(palette) // mode_len
+            if palette_size == 16 and not all_gray:
+                for i in range(palette_size):
+                    gray_palette[i] = 256 * i // palette_size
+
+        height_funcs = {
+            "P": lambda pixel: gray_palette[pixel],
+            "RGB": rgb_to_gray,
+            "RGBA": rgb_to_gray,
+            "I": lambda pixel: pixel >> 8,
+            "L": lambda pixel: pixel,
+            "LA": lambda pixel: pixel[0],
+        }
+
+        height_func = height_funcs.get(im.mode)
+        if height_func is None:
+            raise ValidationException(f"Unsupported image mode: {im.mode}.")
+
+        # Create a histogram based on the height of the pixels.
+        self.histogram = [0] * 256
+        for pixel in im.getdata():
+            self.histogram[height_func(pixel)] += 1

--- a/bananas_api/new_upload/validate.py
+++ b/bananas_api/new_upload/validate.py
@@ -7,6 +7,7 @@ from ..helpers.enums import (
     ContentType,
     PackageType,
 )
+from .classifiers.heightmap import classify_heightmap
 from .classifiers.newgrf import classify_newgrf
 from .exceptions import (
     BaseSetDoesntMentionFileException,
@@ -54,6 +55,7 @@ READERS = {
 }
 
 CLASSIFIERS = {
+    PackageType.HEIGHTMAP: classify_heightmap,
     PackageType.NEWGRF: classify_newgrf,
 }
 

--- a/bananas_api/tool_reclassify/__main__.py
+++ b/bananas_api/tool_reclassify/__main__.py
@@ -39,7 +39,7 @@ def update_progress(unique_id, version, md5sum_partial, name, error, message, cl
     default="local_storage",
     show_default=True,
 )
-@click.argument("category", type=click.Choice(["newgrf"]))
+@click.argument("category", type=click.Choice(["heightmap", "newgrf"]))
 @click.argument("unique_id", type=str, required=False)
 def main(index_local_folder, storage_local_folder, category, unique_id):
     global TOTAL_ENTRIES

--- a/bananas_api/tool_reclassify/heightmap.py
+++ b/bananas_api/tool_reclassify/heightmap.py
@@ -1,0 +1,18 @@
+import tarfile
+
+from ..new_upload.readers.heightmap import Heightmap
+
+
+def load_heightmap(file):
+    heightmap = Heightmap()
+    with tarfile.open(file) as tar:
+        for member in tar.getmembers():
+            if member.name.lower().endswith(".png"):
+                heightmap_member = member
+                break
+        else:
+            raise Exception("no PNG in tarball")
+
+        heightmap.read(tar.extractfile(heightmap_member))
+
+    return heightmap

--- a/bananas_api/tool_reclassify/reclassify.py
+++ b/bananas_api/tool_reclassify/reclassify.py
@@ -1,15 +1,18 @@
 import glob
 import yaml
 
+from .heightmap import load_heightmap
 from .newgrf import load_newgrf
 
 from ..helpers.enums import Availability
 from ..index.common_disk import Index
+from ..new_upload.classifiers.heightmap import classify_heightmap
 from ..new_upload.classifiers.newgrf import classify_newgrf
 from ..new_upload.session_validation import validate_packet_size
 
 
 CLASSIFICATION_TO_FUNCTION = {
+    "heightmap": (load_heightmap, classify_heightmap),
     "newgrf": (load_newgrf, classify_newgrf),
 }
 


### PR DESCRIPTION
This PR will make uploading heightmaps a lot slower .. some can take up to 20s to analyze. This is nothing new for BaNaNaS, as some NewGRFs take almost a minute. So in that sense .. this brings heightmaps on-par with NewGRFs.

Current classification:
https://gist.github.com/TrueBrain/57ebe63f17ef3dfcefabafa2af29cfe5

There is a `debug=` tag in there, which shows the height histogram of the heightmap, on which the `terrain-type` is based. It seems to show a good balance. It gives an indication to the user what to expect when you would create a game with this (assuming you use a sane Highest Peak setting, ofc).