### PR TITLE
Fix: bring the image size limit of PIL in line

### DIFF
--- a/bananas_api/new_upload/readers/heightmap.py
+++ b/bananas_api/new_upload/readers/heightmap.py
@@ -5,6 +5,10 @@ from PIL import Image
 from ..exceptions import ValidationException
 from ...helpers.enums import PackageType
 
+# Limit the size of heightmaps, as otherwise it could allocate a lot of
+# memory for clients loading the map.
+Image.MAX_IMAGE_PIXELS = 16384 * 16384
+
 
 def rgb_to_gray(color):
     return ((color[0] * 19595) + (color[1] * 38470) + (color[2] * 7471)) // 65536
@@ -47,13 +51,10 @@ class Heightmap:
 
         try:
             im = Image.open(fp)
+        except Image.DecompressionBombError:
+            raise ValidationException("Image is too large.")
         except Exception:
             raise ValidationException("File is not a valid image.")
-
-        # Limit the size of heightmaps, as otherwise it could allocate a lot of
-        # memory for clients loading the map.
-        if im.width * im.height > 16384 * 16384:
-            raise ValidationException("Image is too large.")
 
         self.size = im.size
 


### PR DESCRIPTION
The intention of the current code is to limit heightmap to at most 16384 * 16384. However, the actual limit is smaller due to PIL having a similar protection mechanism.

This patch sets the PIL limit to match our intention.

Locally tested.