### PR TITLE
Change: create a new event-loop on startup, instead of assuming it exists

### DIFF
--- a/bananas_api/__main__.py
+++ b/bananas_api/__main__.py
@@ -15,6 +15,7 @@ from .helpers.content_save import click_content_save
 from .helpers.user_session import (
     click_user_session,
     register_webroutes,
+    start_check_expire,
 )
 from .new_upload.session import click_cleanup_graceperiod
 from .new_upload.session_publish import click_storage
@@ -115,8 +116,10 @@ def main(bind, web_port, tusd_port, behind_proxy):
     # Always make sure "fallback" comes last. It has a catch-all rule.
     webapp.add_routes(fallback.routes)
 
+    loop = asyncio.new_event_loop()
+    start_check_expire(loop)
+
     # Start tusd as part of the application
-    loop = asyncio.get_event_loop()
     for host in bind:
         if ":" in host:
             host = f"[{host}]"

--- a/bananas_api/helpers/user_session.py
+++ b/bananas_api/helpers/user_session.py
@@ -89,6 +89,10 @@ async def check_expire():
             user.check_expire()
 
 
+def start_check_expire(loop):
+    loop.create_task(check_expire())
+
+
 def get_session_expire():
     return SESSION_EXPIRE
 
@@ -136,7 +140,3 @@ def click_user_session(user, user_session_expire, user_login_expire, user_sessio
 
     for user_class in user:
         _methods[user_class.method] = user_class
-
-    # Start the expire check via an async task
-    loop = asyncio.get_event_loop()
-    loop.create_task(check_expire())


### PR DESCRIPTION
This fixes the warning that there is no event-loop yet (but it is created for you nevertheless).