### PR TITLE
Add: allow defining the URL to use for GitHub for user authentication

### DIFF
--- a/bananas_api/user/github.py
+++ b/bananas_api/user/github.py
@@ -13,6 +13,8 @@ from ..helpers.web_routes import (
 
 GITHUB_CLIENT_ID = None
 GITHUB_CLIENT_SECRET = None
+GITHUB_API_URL = None
+GITHUB_URL = None
 
 _github_states = {}
 
@@ -23,11 +25,27 @@ _github_states = {}
     "--user-github-client-secret",
     help="GitHub client secret. Always use this via an environment variable! (user=github only)",
 )
-def click_user_github(user_github_client_id, user_github_client_secret):
-    global GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET
+@click.option(
+    "--user-github-api-url",
+    help="GitHub API URL to use.",
+    default="https://api.github.com",
+    show_default=True,
+    metavar="URL",
+)
+@click.option(
+    "--user-github-url",
+    help="GitHub URL to use.",
+    default="https://github.com",
+    show_default=True,
+    metavar="URL",
+)
+def click_user_github(user_github_client_id, user_github_client_secret, user_github_api_url, user_github_url):
+    global GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_API_URL, GITHUB_URL
 
     GITHUB_CLIENT_ID = user_github_client_id
     GITHUB_CLIENT_SECRET = user_github_client_secret
+    GITHUB_API_URL = user_github_api_url
+    GITHUB_URL = user_github_url
 
 
 class User(BaseUser):
@@ -41,6 +59,9 @@ class User(BaseUser):
             raise Exception("GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET should be set via environment")
 
         self._github = GithubClient(client_id=GITHUB_CLIENT_ID, client_secret=GITHUB_CLIENT_SECRET)
+        self._github.access_token_url = f"{GITHUB_URL}/login/oauth/access_token"
+        self._github.base_url = GITHUB_API_URL
+        self._github.user_info_url = f"{GITHUB_API_URL}/user"
 
     def get_authorize_page(self):
         # Chance on collision is really low, but would be really annoying. So


### PR DESCRIPTION
As GitHub is IPv4-only, sometimes there is a need to proxy GitHub via other domains to enable IPv6 connectivity. For those cases, these settings are useful.