### PR TITLE
Change: use a C-module to analyze heightmap

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r regression_runner/requirements.txt
+        python setup.py install
 
     - name: Install tusd
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .coverage
 /.env
 /BaNaNaS
+/build
 /data
 /htmlcov
 /local_storage

--- a/bananas_api/new_upload/readers/heightmap.py
+++ b/bananas_api/new_upload/readers/heightmap.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from PIL import Image
+import _bananas_api
 
 from ..exceptions import ValidationException
 from ...helpers.enums import PackageType
@@ -39,57 +39,19 @@ class Heightmap:
         @type fp: File-like object
         """
 
-        pos = fp.tell()
+        image_data = fp.read()
+
         md5sum = hashlib.md5()
-        md5sum.update(fp.read())
+        md5sum.update(image_data)
         self.md5sum = md5sum.digest()
-        fp.seek(pos, 0)
 
-        try:
-            im = Image.open(fp)
-        except Exception:
-            raise ValidationException("File is not a valid image.")
+        info = _bananas_api.heightmap(image_data)
+        if info["error"]:
+            raise ValidationException(info["error"])
 
-        # Limit the size of heightmaps, as otherwise it could allocate a lot of
-        # memory for clients loading the map.
-        if im.width * im.height > 16384 * 16384:
-            raise ValidationException("Image is too large.")
+        if sum(info["histogram"]) != info["width"] * info["height"]:
+            print(sum(info["histogram"]), info["width"] * info["height"])
+            raise ValidationException("Histogram does not match image size")
 
-        self.size = im.size
-
-        # The following code is based on https://github.com/OpenTTD/OpenTTD/blob/master/src/heightmap.cpp
-        # to mimic the heightmap loading in OpenTTD as much as possible.
-
-        if im.palette:
-            palette = im.palette.palette
-            mode_len = len(im.palette.mode)
-
-            gray_palette = []
-            all_gray = True
-            for i in range(0, len(palette), mode_len):
-                color = palette[i : i + mode_len]
-                all_gray = all_gray and (color[0] == color[1] and color[1] == color[2])
-                gray_palette.append(rgb_to_gray(color))
-
-            palette_size = len(palette) // mode_len
-            if palette_size == 16 and not all_gray:
-                for i in range(palette_size):
-                    gray_palette[i] = 256 * i // palette_size
-
-        height_funcs = {
-            "P": lambda pixel: gray_palette[pixel],
-            "RGB": rgb_to_gray,
-            "RGBA": rgb_to_gray,
-            "I": lambda pixel: pixel >> 8,
-            "L": lambda pixel: pixel,
-            "LA": lambda pixel: pixel[0],
-        }
-
-        height_func = height_funcs.get(im.mode)
-        if height_func is None:
-            raise ValidationException(f"Unsupported image mode: {im.mode}.")
-
-        # Create a histogram based on the height of the pixels.
-        self.histogram = [0] * 256
-        for pixel in im.getdata():
-            self.histogram[height_func(pixel)] += 1
+        self.size = (info["width"], info["height"])
+        self.histogram = info["histogram"]

--- a/regression/311_invalid_heightmap.yaml
+++ b/regression/311_invalid_heightmap.yaml
@@ -4,4 +4,4 @@ steps:
 - file-upload: scenario.scn
   name: heightmap.png
 - api: new-package/publish
-  error: "heightmap.png: File is not a valid image."
+  error: "heightmap.png: File is not a PNG image."

--- a/requirements.base
+++ b/requirements.base
@@ -7,7 +7,6 @@ gitpython
 marshmallow
 marshmallow-enum
 openttd-helpers
-Pillow
 python-dateutil
 PyYAML
 sentry_sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ marshmallow-enum==1.5.1
 multidict==6.0.4
 openttd-helpers==1.4.0
 packaging==23.1
-Pillow==9.5.0
 pycparser==2.21
 PyJWT==2.7.0
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup, Extension
+
+def main():
+    setup(name="bananas-api",
+          version="1.0.0",
+          ext_modules=[Extension("_bananas_api", ["src/_bananas_api.cpp", "src/_heightmap.cpp"], libraries=["png", "z"])])
+
+if __name__ == "__main__":
+    main()

--- a/src/_bananas_api.cpp
+++ b/src/_bananas_api.cpp
@@ -1,0 +1,14 @@
+#include "_bananas_api.h"
+
+static PyMethodDef BananasApiMethods[] = {
+	{"heightmap", HeightmapReadAndAnalyze, METH_VARARGS, "Read and analyze a heightmap."},
+	{nullptr, nullptr, 0, nullptr}
+};
+
+static struct PyModuleDef module = { PyModuleDef_HEAD_INIT, "_bananas_api", nullptr, -1, BananasApiMethods };
+
+PyMODINIT_FUNC
+PyInit__bananas_api(void)
+{
+	return PyModule_Create(&module);
+}

--- a/src/_bananas_api.h
+++ b/src/_bananas_api.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/**
+ * Read and analyze a heightmap.
+ *
+ * This is done in C++, as there are no good libraries for this in Python.
+ * opencv, Pillow, vips, etc, they all have their own issues. Most of them
+ * read the PNG in full at once. vips is the exception, but doesn't allow
+ * reading the palette.
+ *
+ * Reading the PNG in full at once is problematic, as a 16k by 16k heightmap
+ * will consume 400+ MiB of RAM, which our backend simply doesn't have spare.
+ *
+ * Instead, do this in C++, using libpng directly. This has three advantages:
+ * 1) It copies over the code used in OpenTTD, so we know it does the same.
+ * 2) It uses very little memory, as the decoded PNG is actually never stored.
+ * 3) It is fast, as iterations over long byte-strings is still very slow in Python.
+ *
+ * Arguments: bytes
+ * Result: dict with "width", "height", "histogram", and "error".
+ *   If "error" is non-empty, the rest of the values cannot be trusted.
+ */
+PyObject *HeightmapReadAndAnalyze(PyObject *self, PyObject *args);

--- a/src/_heightmap.cpp
+++ b/src/_heightmap.cpp
@@ -1,0 +1,191 @@
+#include "_bananas_api.h"
+
+#include <png.h>
+#include <string>
+
+static constexpr Py_ssize_t CHUNK_SIZE = 1024;
+static constexpr int HISTOGRAM_SIZE = 256;
+
+struct HeightmapResult {
+	/* Internal variables. */
+	bool has_palette = false;
+	bool is_interlaced = false;
+	uint8_t channels = 0;
+	uint8_t gray_palette[256] = {};
+
+	/* Returning variables. */
+	uint32_t width = 0;
+	uint32_t height = 0;
+	uint32_t histogram[HISTOGRAM_SIZE] = {};
+	std::string error = "";
+
+	PyObject *ToPyObject()
+	{
+		auto list = PyList_New(HISTOGRAM_SIZE);
+		for (int i = 0; i < HISTOGRAM_SIZE; i++) {
+			PyList_SetItem(list, i, PyLong_FromLong(this->histogram[i]));
+		}
+
+		return Py_BuildValue(
+			"{s:s,s:i,s:i,s:O}",
+			"error", this->error.c_str(),
+			"width", this->width,
+			"height", this->height,
+			"histogram", list
+		);
+	}
+};
+
+/* The following code is based on https://github.com/OpenTTD/OpenTTD/blob/master/src/heightmap.cpp */
+static inline uint8_t RGBToGrayscale(uint8_t red, uint8_t green, uint8_t blue)
+{
+	return ((red * 19595) + (green * 38470) + (blue * 7471)) / 65536;
+}
+
+static void HeightmapCallbackRow(png_structp png_ptr, png_bytep new_row, png_uint_32 row_num, int pass)
+{
+	HeightmapResult *result = reinterpret_cast<HeightmapResult *>(png_get_progressive_ptr(png_ptr));
+
+	/* No updated for interlaced. */
+	if (new_row == nullptr) {
+		return;
+	}
+
+	/* Interlaced has different amount of pixels set depending on the pass.
+	* As we only care about the pixels, and not their location, we can just
+	* adjust the size we read. */
+	auto size = result->width;
+	if (result->is_interlaced) {
+		switch (pass) {
+			case 0: size = (size + 7) / 8; break;
+			case 1: size = (size + 3) / 8; break;
+			case 2: size = (size + 3) / 4; break;
+			case 3: size = (size + 1) / 4; break;
+			case 4: size = (size + 1) / 2; break;
+			case 5: size = (size + 0) / 2; break;
+			case 6: size = (size + 0) / 1; break;
+			default: return;
+		}
+	}
+
+	/* The following code is based on https://github.com/OpenTTD/OpenTTD/blob/master/src/heightmap.cpp */
+	for (uint32_t x = 0; x < size; x++) {
+		uint x_offset = x * result->channels;
+
+		uint8_t pixel;
+		if (result->has_palette) {
+			pixel = result->gray_palette[new_row[x_offset]];
+		} else if (result->channels == 3) {
+			pixel = RGBToGrayscale(new_row[x_offset + 0], new_row[x_offset + 1], new_row[x_offset + 2]);
+		} else {
+			pixel = new_row[x_offset];
+		}
+
+		result->histogram[pixel] += 1;
+	}
+}
+
+static void HeightmapCallbackInfo(png_structp png_ptr, png_infop info_ptr)
+{
+	HeightmapResult *result = reinterpret_cast<HeightmapResult *>(png_get_progressive_ptr(png_ptr));
+
+	png_set_packing(png_ptr);
+	png_set_strip_alpha(png_ptr);
+	png_set_strip_16(png_ptr);
+	png_read_update_info(png_ptr, info_ptr);
+
+	if ((png_get_channels(png_ptr, info_ptr) != 1) && (png_get_channels(png_ptr, info_ptr) != 3) && (png_get_bit_depth(png_ptr, info_ptr) != 8)) {
+		result->error = "PNG uses unsupported channels or bit depth.";
+		return;
+	}
+	if (png_get_interlace_type(png_ptr, info_ptr) != PNG_INTERLACE_NONE && png_get_channels(png_ptr, info_ptr) != 1) {
+		result->error = "Interlaced PNGs with more than one channel are not supported.";
+		return;
+	}
+
+	result->width = png_get_image_width(png_ptr, info_ptr);
+	result->height = png_get_image_height(png_ptr, info_ptr);
+
+	if (result->width * result->height > 16384 * 16384) {
+		result->error = "Image is too large.";
+		return;
+	}
+
+	result->is_interlaced = png_get_interlace_type(png_ptr, info_ptr) != PNG_INTERLACE_NONE;
+	result->has_palette = png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE;
+	result->channels = png_get_channels(png_ptr, info_ptr);
+
+	/* The following code is based on https://github.com/OpenTTD/OpenTTD/blob/master/src/heightmap.cpp */
+	if (result->has_palette) {
+		int i;
+		int palette_size;
+		png_color *palette;
+		bool all_gray = true;
+
+		png_get_PLTE(png_ptr, info_ptr, &palette, &palette_size);
+		for (i = 0; i < palette_size && (palette_size != 16 || all_gray); i++) {
+			all_gray &= palette[i].red == palette[i].green && palette[i].red == palette[i].blue;
+			result->gray_palette[i] = RGBToGrayscale(palette[i].red, palette[i].green, palette[i].blue);
+		}
+
+		/**
+		 * For a non-gray palette of size 16 we assume that
+		 * the order of the palette determines the height;
+		 * the first entry is the sea (level 0), the second one
+		 * level 1, etc.
+		 */
+		if (palette_size == 16 && !all_gray) {
+			for (i = 0; i < palette_size; i++) {
+				result->gray_palette[i] = 256 * i / palette_size;
+			}
+		}
+	}
+}
+
+PyObject *HeightmapReadAndAnalyze(PyObject *self, PyObject *args)
+{
+	HeightmapResult result = {};
+
+	unsigned char *png_bytes;
+	Py_ssize_t png_length;
+
+	/* We expect one argument: bytes. */
+	if (!PyArg_ParseTuple(args, "y#", &png_bytes, &png_length)) {
+		result.error = "Invalid arguments.";
+		return result.ToPyObject();
+	}
+
+	/* Make sure this is actually a PNG. */
+	if (png_length < 4 || png_sig_cmp(png_bytes, 0, 4) != 0) {
+		result.error = "File is not a PNG image.";
+		return result.ToPyObject();
+	}
+
+	auto png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	if (png_ptr == nullptr) {
+		result.error = "Failed to create PNG read struct.";
+		return result.ToPyObject();
+	}
+	auto info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == nullptr || setjmp(png_jmpbuf(png_ptr))) {
+		result.error = "Failed to create PNG info struct.";
+		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+		return result.ToPyObject();
+	}
+
+	/* Use progressive reading, so we never actually store the final result. */
+	png_set_progressive_read_fn(png_ptr, &result, HeightmapCallbackInfo, HeightmapCallbackRow, nullptr);
+
+	/* Read the buffer till it is empty. */
+	while (png_length > 0) {
+		auto remainder = std::min(CHUNK_SIZE, png_length);
+
+		png_process_data(png_ptr, info_ptr, png_bytes, remainder);
+
+		png_bytes += remainder;
+		png_length -= remainder;
+	}
+
+	png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+	return result.ToPyObject();
+}


### PR DESCRIPTION
This fixes various of problems:
- The analysis itself consumes nearly no memory (where before it extracted the PNG in memory in full).
- The analysis is significantly faster (1000x faster).
- It uses the exact same code as OpenTTD, so no accidental conversion mistakes.

This means we can finally analyze heightmaps up to 256M tiles with ease.

Closes #373 (no longer applicable, as we no longer use Pillow)