### PR TITLE
Fix: warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim as builder
+FROM python:3.8-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
Nowedays there is a linter complaining that if you do FROM you should do AS, not "as"