### PR TITLE
Fix #499, #523: allow license.md/changelog.md/readme.md as well as metadata:url for base sets

### DIFF
--- a/bananas_api/new_upload/readers/base_graphics.py
+++ b/bananas_api/new_upload/readers/base_graphics.py
@@ -13,6 +13,7 @@ class BaseGraphics(BaseSet):
             "description": str,
             "palette": str,
             "blitter": str,
+            "url": str | None,
         },
         "files": {
             "base": str,

--- a/bananas_api/new_upload/readers/base_music.py
+++ b/bananas_api/new_upload/readers/base_music.py
@@ -11,6 +11,7 @@ class BaseMusic(BaseSet):
             "shortname": str,
             "version": str,
             "description": str,
+            "url": str | None,
         },
         "files": {
             "theme": str,

--- a/bananas_api/new_upload/readers/base_sounds.py
+++ b/bananas_api/new_upload/readers/base_sounds.py
@@ -11,6 +11,7 @@ class BaseSounds(BaseSet):
             "shortname": str,
             "version": str,
             "description": str,
+            "url": str | None,
         },
         "files": {
             "samples": str,

--- a/bananas_api/new_upload/readers/helpers/base_sets.py
+++ b/bananas_api/new_upload/readers/helpers/base_sets.py
@@ -19,6 +19,9 @@ class BaseSet:
     @ivar description: Description of Base Set
     @type description: C{str}
 
+    @ivar url: URL of Base Set
+    @type url: C{str}
+
     @ivar files: Files included in Base Set, with their md5sum
     @type files: C{dict}
     """
@@ -30,6 +33,7 @@ class BaseSet:
         self.unique_id = None
         self.version = None
         self.description = None
+        self.url = None
         self.files = None
 
     def read(self, fp):
@@ -63,9 +67,12 @@ class BaseSet:
             # Check entries we expected but are not there
             for key, key_type in keys.items():
                 if not ini_parser.has_option(section, key):
+                    if key_type == str | None:
+                        continue
                     raise ValidationException(f"Option {section}:{key} is missing.")
+
                 value = ini_parser.get(section, key)
-                if not isinstance(value, key_type):
+                if not isinstance(value, str if key_type == str | None else key_type):
                     raise ValidationException(f"Option {section}:{key} is not a {key_type}.")
 
         # List the files, their md5sum, and the complete md5sum
@@ -95,5 +102,6 @@ class BaseSet:
         self.unique_id = ini_parser.get("metadata", "shortname").encode()
         self.version = ini_parser.get("metadata", "version")
         self.description = ini_parser.get("metadata", "description")
+        self.url = ini_parser.get("metadata", "url", fallback=None)
         self.files = files
         self.md5sum = md5sum

--- a/bananas_api/new_upload/session_validation.py
+++ b/bananas_api/new_upload/session_validation.py
@@ -31,15 +31,16 @@ def validate_license(session):
         session["errors"].append("License is not yet set for this package.")
     elif session["license"] == License.CUSTOM:
         for file_info in session["files"]:
-            if file_info["filename"] == "license.txt":
+            if file_info["filename"] in ("license.txt", "license.md"):
                 break
         else:
-            session["errors"].append("License is set to custom, but no license.txt is uploaded.")
+            session["errors"].append("License is set to custom, but no 'license.txt' or 'license.md' is uploaded.")
     else:
         for file_info in session["files"]:
-            if file_info["filename"] == "license.txt":
+            if file_info["filename"] in ("license.txt", "license.md"):
                 session["errors"].append(
-                    f"License is set to {session['license'].value}; this does not require uploading 'license.txt'."
+                    f"License is set to {session['license'].value}; "
+                    "this does not require uploading 'license.txt' or 'license.md'."
                 )
 
 

--- a/bananas_api/new_upload/validate.py
+++ b/bananas_api/new_upload/validate.py
@@ -97,9 +97,9 @@ PACKAGE_TYPE_PAIRS = {
 
 # readme.txt and changelog.txt can have translations. This can be with the
 # first part of the ISO code, or with the full. For example:
-# readme.txt, readme_nl.txt, readme_nl_NL.txt
+# readme.txt, readme_nl.txt, readme_nl_NL.txt, readme.md
 # All other variantions are not valid.
-txt_regexp = re.compile(r"(readme|changelog)(_[a-z]{2}(_[A-Z]{2})?)?\.txt$")
+txt_regexp = re.compile(r"(readme|changelog)(_[a-z]{2}(_[A-Z]{2})?)?\.(txt|md)$")
 
 
 def _validate_textfile_encoding(fp):
@@ -111,14 +111,14 @@ def _validate_textfile_encoding(fp):
 
 def _read_object(filename, fp):
     lfilename = filename.lower()
-    if lfilename.endswith(".txt"):
-        if filename == "license.txt":
-            _validate_textfile_encoding(fp)
-            return None
-        elif txt_regexp.match(filename):
-            _validate_textfile_encoding(fp)
-            return None
-        elif filename.startswith("lang/"):
+    if filename in ("license.txt", "license.md"):
+        _validate_textfile_encoding(fp)
+        return None
+    elif txt_regexp.match(filename):
+        _validate_textfile_encoding(fp)
+        return None
+    elif lfilename.endswith(".txt"):
+        if filename.startswith("lang/"):
             _validate_textfile_encoding(fp)
             return None
         else:

--- a/regression/100_success_base_sounds.yaml
+++ b/regression/100_success_base_sounds.yaml
@@ -4,10 +4,11 @@ steps:
 - file-upload: nosound.obs
 - file-upload: nosound.cat
 - file-upload: license.txt
+  name: license.md
 - file-upload: readme.txt
-  name: readme_nl.txt
+  name: readme_nl.md
 - file-upload: changelog.txt
-  name: changelog_nl.txt
+  name: changelog_nl.md
 - api: new-package/update
   name: "test"
   version: "v1"

--- a/regression/921_missing_custom_license.yaml
+++ b/regression/921_missing_custom_license.yaml
@@ -6,4 +6,4 @@ steps:
   version: "test"
   license: "Custom"
 - api: new-package/publish
-  error: "License is set to custom, but no license.txt is uploaded."
+  error: "License is set to custom, but no 'license.txt' or 'license.md' is uploaded."

--- a/regression/923_custom_and_defined_license.yaml
+++ b/regression/923_custom_and_defined_license.yaml
@@ -7,4 +7,4 @@ steps:
   version: "test"
   license: "GPL v2"
 - api: new-package/publish
-  error: "License is set to GPL v2; this does not require uploading 'license.txt'."
+  error: "License is set to GPL v2; this does not require uploading 'license.txt' or 'license.md'."

--- a/regression/nosound.obs
+++ b/regression/nosound.obs
@@ -3,6 +3,7 @@ name         = NoSound
 shortname    = NULL
 version      = 0
 description  = A sound pack without any sounds
+url          = http://localhost
 
 [files]
 samples      = nosound.cat


### PR DESCRIPTION
Fixes #499 (no .md variant of license/changelog/readme allowed)
Fixes #523 (no .md variant of license/changelog/readme allowed, and no metadata:url allowed for base sets)

Only testing I've triggered are the amended unit tests.